### PR TITLE
fix(cicd): update permissions on running cicd

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
 
 permissions:
   actions: read


### PR DESCRIPTION
## what
- ~copy over updated cicd configs for GHA~
- Ah, I realized @gberenice setup some slick tooling in our taskit repo to do exactly this
- Opened a PR that executed the task it sync process, https://github.com/masterpointio/terraform-googleworkspace-users-groups-automation/pull/5
- Please review that PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workflow trigger for automated tests on pull requests to improve workflow execution context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->