### PR TITLE
fix: docs, polish readme to include user custom_schemas for the SSO setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ Once you've completed the setup process, your provider block should look like th
 
 ```hcl
 provider "googleworkspace" {
-  # Use 'my_customer' as an alias for your account's customerId to ensure compatibility with Google's API
-  # For example, custom schemas on the user object will fail if the customer_id is set to your actual customer_id
-  # For more details: https://developers.google.com/workspace/admin/directory/reference/rest/v1/schemas/get
+  # Use 'my_customer' as an alias for your account's customerId to ensure compatibility with
+  # Google's API. For example, custom schemas on the user object will fail if the customer_id
+  # is set to your actual customer_id
+  # For more details, see: https://developers.google.com/workspace/admin/directory/reference/rest/v1/schemas/get
   customer_id = "my_customer"
 
   credentials             = "/path/to/credentials/my-google-project-credentials-1234567890.json"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,20 @@ module "googleworkspace_users_groups" {
           role = "member"
         }
       }
+      custom_schemas = [
+        {
+          schema_name = "Client1"
+          schema_values = {
+            Role = "[\"arn:aws:iam::111111111111:role/GoogleAppsAdmin\",\"arn:aws:iam::111111111111:saml-provider/GoogleApps\"]"
+          }
+        },
+        {
+          schema_name = "Client2"
+          schema_values = {
+            Role = "[\"arn:aws:iam::222222222222:role/xyz-identity-reader,arn:aws:iam::222222222222:saml-provider/xyz-identity-acme-gsuite\", \"arn:aws:iam::222222222222:role/xyz-identity-admin,arn:aws:iam::222222222222:saml-provider/xyz-identity-acme-gsuite\"]"
+          }
+        }
+      ]
     }
   }
 

--- a/examples/import-existing-org/users.yaml
+++ b/examples/import-existing-org/users.yaml
@@ -10,10 +10,10 @@ first.last@example.com:
   family_name: Last
   given_name: First
   custom_schemas:
-    - schema_name: AWS_SSO_for_Client123
+    - schema_name: AWS_SSO_for_Client1
       schema_values:
         Role: '["arn:aws:iam::111111111111:role/GoogleAppsAdmin","arn:aws:iam::111111111111:saml-provider/GoogleApps"]'
-    - schema_name: AWS_SSO_for_Client456
+    - schema_name: AWS_SSO_for_Client2
       schema_values:
         Role: '["arn:aws:iam::222222222222:role/xyz-identity-reader,arn:aws:iam::222222222222:saml-provider/xyz-identity-acme-gsuite", "arn:aws:iam::222222222222:role/xyz-identity-admin,arn:aws:iam::222222222222:saml-provider/xyz-identity-acme-gsuite"]'
 


### PR DESCRIPTION
## what
- refine example in readme to include how we reference SSO with AWS

## why
- let's make it explicitly clear how this module makes it easier to manage Google Workspace settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README for improved clarity and added an example demonstrating how to specify custom schemas for Google Workspace users.
  - Reformatted provider block comments for better readability.
  - Included an example of assigning complex role information to users using custom schemas.

- **Style**
  - Updated schema names in the example user configuration for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->