### PR TITLE
fix: pin GitHub Actions to commit SHAs (INT-326)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Trunk Check
-        uses: trunk-io/trunk-action@4d5ecc89b2691705fd08c747c78652d2fc806a94 # v1.1.19
+        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
 
   conventional-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         tf: [tofu, terraform]
     steps:
-      - uses: masterpointio/github-action-tf-test@c3b619f3bca9e4f482b9e0fb3166ab3f02d9d54c # v1.0.0
+      - uses: masterpointio/github-action-tf-test@c1e41998f67925ac3f34e0bbcfcaa4a44d1f0cd9 # v1.0.1
         with:
           tf_type: ${{ matrix.tf }}
           aws_role_arn: ${{ vars.TF_TEST_AWS_ROLE_ARN }}

--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Create Token for MasterpointBot App
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a #v2.1.0
@@ -28,7 +28,7 @@ jobs:
 
       - name: Upgrade
         id: trunk-upgrade
-        uses: trunk-io/trunk-action/upgrade@4d5ecc89b2691705fd08c747c78652d2fc806a94 # v1.1.19
+        uses: trunk-io/trunk-action/upgrade@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           reviewers: "@masterpointio/masterpoint-internal"

--- a/.trunk/configs/.isort.cfg
+++ b/.trunk/configs/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+profile=black

--- a/.trunk/configs/ruff.toml
+++ b/.trunk/configs/ruff.toml
@@ -1,0 +1,5 @@
+# Generic, formatter-friendly config.
+select = ["B", "D3", "E", "F"]
+
+# Never enforce `E501` (line length violations). This should be handled by formatters.
+ignore = ["E501"]

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,12 +2,12 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.24.0
+  version: 1.25.0
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.1
+      ref: v1.7.6
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -20,17 +20,22 @@ lint:
     # Incompatible with some Terraform features: https://github.com/tenable/terrascan/issues/1331
     - terrascan
   enabled:
-    - renovate@41.17.2
-    - tofu@1.10.1
-    - actionlint@1.7.7
-    - checkov@3.2.447
+    - taplo@0.10.0
+    - bandit@1.9.4
+    - black@26.3.1
+    - isort@8.0.1
+    - ruff@0.15.9
+    - renovate@43.104.1
+    - tofu@1.11.5
+    - actionlint@1.7.12
+    - checkov@3.2.513
     - git-diff-check
-    - markdownlint@0.45.0
-    - prettier@3.6.2
-    - tflint@0.58.0
-    - trivy@0.63.0
-    - trufflehog@3.89.2
-    - yamllint@1.37.1
+    - markdownlint@0.48.0
+    - prettier@3.8.1
+    - tflint@0.61.0
+    - trivy@0.69.3
+    - trufflehog@3.94.2
+    - yamllint@1.38.0
   ignore:
     - linters: [tofu]
       paths:

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,8 @@ locals {
       for user_key, user in local._user_with_groups : [
         for group_key, group in user.groups : merge(group, {
           user_primary_email = user.primary_email,
-          group_email        = googleworkspace_group.defaults[group_key].email
+          group_key          = group_key,
+          group_email        = try(var.groups[group_key].email, "invalid-group:${group_key}")
         })
       ]
     ]) : "${obj.group_email}/${obj.user_primary_email}" => obj
@@ -121,6 +122,10 @@ resource "googleworkspace_group_member" "user_to_groups" {
   type     = upper(each.value.type)
 
   lifecycle {
+    precondition {
+      condition     = contains(keys(var.groups), each.value.group_key)
+      error_message = "User references group '${each.value.group_key}' which does not exist in var.groups."
+    }
     ignore_changes = [
       delivery_settings, # ignore user changes to delivery settings
     ]


### PR DESCRIPTION
## Info

- Pins all `uses:` references in GitHub Actions workflows to full commit SHAs.

## References

- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to latest pinned versions
  * Upgraded Trunk CLI and plugin versions for improved tooling
  * Enhanced code quality checks with additional linter configurations and enabled new linters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->